### PR TITLE
Whole reply content was added into message's metadata.

### DIFF
--- a/src/Take.Blip.Builder.UnitTests/InputReplyHandlerTests.cs
+++ b/src/Take.Blip.Builder.UnitTests/InputReplyHandlerTests.cs
@@ -48,7 +48,8 @@ namespace Take.Blip.Builder.UnitTests
             // Assert
             returnedMessage.Content.Equals(plainText);
             Assert.True(messageHasChanged);
-            Assert.Null(returnedMessage.Metadata);
+            Assert.True(returnedMessage.Metadata.ContainsKey(InputReplyHandler.REPLY_CONTENT));
+            Assert.False(returnedMessage.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_ID));
         }
 
         [Fact]
@@ -68,26 +69,7 @@ namespace Take.Blip.Builder.UnitTests
         }
 
         [Fact]
-        public async Task HandleMessage_WhenPropertyValueFromInReplyToIsNull()
-        {
-            // Arrange
-            var plainText = MockPlainText();
-            Message.Content = MockReplyMessage();
-
-            // Act
-            var (messageHasChanged, returnedMessage) = InputHandler.HandleMessage(Message);
-
-            // Assert
-            returnedMessage.Content.Equals(plainText);
-            Assert.True(messageHasChanged);
-            Assert.True(returnedMessage.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_ID));
-            Assert.False(returnedMessage.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_TYPE));
-            Assert.False(returnedMessage.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_VALUE));
-            Assert.True(returnedMessage.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_DIRECTION));
-        }
-
-        [Fact]
-        public async Task HandleMessage_WhenMessageAlreadyHaveMetadata()
+        public async Task HandleMessage_WhenMessageHasMetadata()
         {
             // Arrange
             var traceIdentity = new Identity(Guid.NewGuid().ToString(), "msging.net");
@@ -210,9 +192,7 @@ namespace Take.Blip.Builder.UnitTests
         {
             Assert.True(messageHasChanged);
             Assert.True(message.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_ID));
-            Assert.True(message.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_TYPE));
-            Assert.True(message.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_VALUE));
-            Assert.True(message.Metadata.ContainsKey(InputReplyHandler.IN_REPLY_TO_DIRECTION));
+            Assert.True(message.Metadata.ContainsKey(InputReplyHandler.REPLY_CONTENT));
         }
 
         private static Document MockPlainText() =>

--- a/src/Take.Blip.Builder/InputReplyHandler.cs
+++ b/src/Take.Blip.Builder/InputReplyHandler.cs
@@ -12,10 +12,8 @@ using Take.Blip.Builder.Models;
 /// </summary>
 public class InputReplyHandler : IInputMessageHandler
 {
+    public const string REPLY_CONTENT = "#replyContent";
     public const string IN_REPLY_TO_ID = "#inReplyToId";
-    public const string IN_REPLY_TO_TYPE = "#inReplyToType";
-    public const string IN_REPLY_TO_VALUE = "#inReplyToValue";
-    public const string IN_REPLY_TO_DIRECTION = "#inReplyToDirection";
 
     private readonly Document _emptyContent = new PlainText() { Text = string.Empty };
     private readonly IDocumentSerializer _documentSerializer;
@@ -83,24 +81,17 @@ public class InputReplyHandler : IInputMessageHandler
 
     private void TryAddMetadataIntoMessage(Message message, Reply reply)
     {
-        if (reply.InReplyTo == null)
-        {
-            return;
-        }
-
         message.Metadata ??= new Dictionary<string, string>();
+        message?.Metadata?.TryAdd(REPLY_CONTENT, _documentSerializer.Serialize(reply));
 
-        if (!message.Metadata.ContainsKey(IN_REPLY_TO_ID) && !string.IsNullOrEmpty(reply.InReplyTo.Id))
+        if (ShouldAddMetadataInReplyToId(message, reply))
         {
             message?.Metadata?.TryAdd(IN_REPLY_TO_ID, reply.InReplyTo.Id);
         }
-
-        if (reply.InReplyTo.Value != null)
-        {
-            message?.Metadata?.TryAdd(IN_REPLY_TO_TYPE, reply.InReplyTo.Type);
-            message?.Metadata?.TryAdd(IN_REPLY_TO_VALUE, _documentSerializer.Serialize(reply.InReplyTo.Value));
-        }
-
-        message?.Metadata?.TryAdd(IN_REPLY_TO_DIRECTION, reply.InReplyTo.Direction.ToString());
     }
+
+    private bool ShouldAddMetadataInReplyToId(Message message, Reply reply) =>
+           reply.InReplyTo != null
+        && !message.Metadata.ContainsKey(IN_REPLY_TO_ID)
+        && !string.IsNullOrEmpty(reply.InReplyTo.Id);
 }


### PR DESCRIPTION
- The #inReplyToType, #inReplyToValue and #inReplyToDirection metadatas were replaced to #replyContent;
- A method named ShouldAddMetadataInReplyToId was created to validates if #inReplyToId metadata should be added;
- The unit test HandleMessage_WhenPropertyValueFromInReplyToIsNull was removed.